### PR TITLE
Disable fallback using global textlint when local textlint not found.

### DIFF
--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -1,4 +1,4 @@
-require "mkmf"
+# require "mkmf"
 require "json"
 
 module Danger
@@ -40,7 +40,14 @@ module Danger
 
     def textlint_path
       local = "./node_modules/.bin/textlint"
-      File.exist?(local) ? local : find_executable("textlint")
+
+      # NOTE: Danger using method_missing hack for parse 'warn', 'fail' in Dangerfile.
+      # Same issue will occur 'message' when require 'mkmf'. Because 'mkmf' provide 'message' method.
+      # Then, disable find executable textlint until danger fix this issue.
+
+      # File.exist?(local) ? local : find_executable("textlint")
+      raise "textlint not found in ./node_modules/.bin/textlint" unless File.exist?(local)
+      local
     end
 
     def textlint_command(bin, target_files)


### PR DESCRIPTION
This PR fix bug that `message` in Dangerfile is not working correctly when install danger-textlint.

danger using method_missing hack for parse `warn` and `fail` keyword in Dangerfile.
https://github.com/danger/danger/blob/master/lib/danger/danger_core/dangerfile.rb#L44-L56

Same issue will occur in 'message' keyword when require 'mkmf'. Because 'mkmf' provide `message` method.
http://www.rubydoc.info/stdlib/mkmf/MakeMakefile:message