### PR TITLE
Add max_comment_num option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -153,3 +153,6 @@ Security/YAMLLoad:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false

--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -101,7 +101,7 @@ module Danger
       limited_errors = errors
       if max_comment_num && limited_errors.size > max_comment_num
         limited_errors = limited_errors.first(max_comment_num)
-        send("warn", "Textlint reported more than #{max_comment_num} problems but danger-textlint doesn't to show some comments. Please run textlint in your machine and check all problems.")
+        send("warn", "Textlint reported more than #{max_comment_num} problems, but danger-textlint doesn't to display all problems. Please run textlint in your machine and check all problems.")
       end
 
       limited_errors.each do |error|

--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -14,6 +14,11 @@ module Danger
   #          textlint.max_severity = "warn"
   #          textlint.lint
   #
+  # @example Max inline comment number. If you want disable this feature, please set nil. Default: nil
+  #
+  #          textlint.max_comment_num = 5
+  #          textlint.lint
+  #
   # @see  Kesin11/danger-textlint
   # @tags lint, textlint
   #
@@ -26,6 +31,11 @@ module Danger
     # choice: nil or "warn"
     # @return [String]
     attr_accessor :max_severity
+
+    # Set max danger reporting comment number
+    # choice: nil or integer
+    # @return [String]
+    attr_accessor :max_comment_num
 
     # Execute textlint and send comment
     # @return [void]
@@ -88,7 +98,13 @@ module Danger
     end
 
     def send_comment(errors)
-      errors.each do |error|
+      limited_errors = errors
+      if max_comment_num && limited_errors.size > max_comment_num
+        limited_errors = limited_errors.first(max_comment_num)
+        send("warn", "Textlint reported more than #{max_comment_num} problems but danger-textlint doesn't to show some comments. Please run textlint in your machine and check all problems.")
+      end
+
+      limited_errors.each do |error|
         send(error[:severity], error[:message], file: error[:file_path], line: error[:line])
       end
     end

--- a/spec/textlint_spec.rb
+++ b/spec/textlint_spec.rb
@@ -82,7 +82,7 @@ module Danger
 
       context "with .max_severity = 'warn'" do
         before do
-          @textlint.max_severity = 'warn'
+          @textlint.max_severity = "warn"
           @textlint.lint
         end
 

--- a/spec/textlint_spec.rb
+++ b/spec/textlint_spec.rb
@@ -82,7 +82,7 @@ module Danger
 
       context "with .max_severity = 'warn'" do
         before do
-          @textlint.max_severity = "warn"
+          @textlint.max_severity = 'warn'
           @textlint.lint
         end
 
@@ -98,6 +98,33 @@ module Danger
           expect(violation_report[:warnings][0]).to eq(
             Violation.new(expect_message, false, "articles/1.md", 3)
           )
+        end
+      end
+
+      context "with .max_comment_num = 5" do
+        let(:max_comment_num) { 5 }
+        before do
+          @textlint.max_comment_num = max_comment_num
+          @textlint.lint
+        end
+
+        it "status_report" do
+          status_report = @textlint.status_report
+          expect(status_report[:errors].size).to eq(max_comment_num)
+        end
+
+        it "violation_report" do
+          violation_report = @textlint.violation_report
+          expect(violation_report[:errors].size).to eq(max_comment_num)
+        end
+
+        it "danger comment" do
+          # find not inline comment
+          comment = @textlint.violation_report[:warnings].find do |warning|
+            warning.message.match(/Textlint reported more than/)
+          end
+
+          expect(comment).not_to be_nil
         end
       end
     end


### PR DESCRIPTION
Fix #1 

Add new option `max_comment_num` that limit danger-textlint comment num.