### PR TITLE
Do not execute `textlint.lint` when there are no target files.

### DIFF
--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -40,12 +40,11 @@ module Danger
     # Execute textlint and send comment
     # @return [void]
     def lint
-      unless target_files.empty?
-        bin = textlint_path
-        result_json = run_textlint(bin, target_files)
-        errors = parse(result_json)
-        send_comment(errors)
-      end
+      return if target_files.empty?
+      bin = textlint_path
+      result_json = run_textlint(bin, target_files)
+      errors = parse(result_json)
+      send_comment(errors)
     end
 
     private

--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -40,7 +40,7 @@ module Danger
     # Execute textlint and send comment
     # @return [void]
     def lint
-      if target_files.size > 0
+      unless target_files.empty?
         bin = textlint_path
         result_json = run_textlint(bin, target_files)
         errors = parse(result_json)

--- a/lib/textlint/plugin.rb
+++ b/lib/textlint/plugin.rb
@@ -40,10 +40,12 @@ module Danger
     # Execute textlint and send comment
     # @return [void]
     def lint
-      bin = textlint_path
-      result_json = run_textlint(bin, target_files)
-      errors = parse(result_json)
-      send_comment(errors)
+      if target_files.size > 0
+        bin = textlint_path
+        result_json = run_textlint(bin, target_files)
+        errors = parse(result_json)
+        send_comment(errors)
+      end
     end
 
     private

--- a/spec/textlint_spec.rb
+++ b/spec/textlint_spec.rb
@@ -62,7 +62,10 @@ module Danger
       end
 
       # stub for simulate to run textlint
-      before { allow(@textlint).to receive(:run_textlint).and_return fixture }
+      before do
+        allow(@textlint).to receive(:run_textlint).and_return fixture
+        allow(@textlint).to receive(:target_files).and_return ['']
+      end
 
       context "with default max_severity" do
         before { @textlint.lint }

--- a/spec/textlint_spec.rb
+++ b/spec/textlint_spec.rb
@@ -64,7 +64,7 @@ module Danger
       # stub for simulate to run textlint
       before do
         allow(@textlint).to receive(:run_textlint).and_return fixture
-        allow(@textlint).to receive(:target_files).and_return ['']
+        allow(@textlint).to receive(:target_files).and_return [""]
       end
 
       context "with default max_severity" do


### PR DESCRIPTION
Currently `textlint.lint` will be executed even though there are no target files.
The result shows help message of `textlint` itself.

This patch ignores the execution when it's without target files.