### PR TITLE
Bump bundler to 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,9 @@ rvm:
   - 2.5
   - 2.6
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 script:
     - bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (~> 2.0)
   danger-textlint!
   guard (~> 2.14)
   guard-rspec (~> 4.7)
@@ -133,4 +133,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.1
+   2.0.1

--- a/danger-textlint.gemspec
+++ b/danger-textlint.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 
   # General ruby development
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
 
   # Testing support


### PR DESCRIPTION
Recently test with TravisCI ruby 2.5.5 failed because CI environment using bundler 2.
Error shows could not found required proper version of bundler.

So it's time to update bundler version.